### PR TITLE
Suggestion: Change to BepInEx 5 for compatibility

### DIFF
--- a/Skul.Mod/Patches/DropRatePatch.cs
+++ b/Skul.Mod/Patches/DropRatePatch.cs
@@ -255,15 +255,19 @@ namespace Skul.Mod
             switch (chapterType)
             {
                 case Chapter.Type.Chapter2:
+                case Chapter.Type.HardmodeChapter2:
                     rarity = Rarity.Rare;
                     break;
                 case Chapter.Type.Chapter3:
+                case Chapter.Type.HardmodeChapter3:
                     rarity = Rarity.Unique;
                     break;
                 case Chapter.Type.Chapter4:
+                case Chapter.Type.HardmodeChapter4:
                     rarity = Rarity.Legendary;
                     break;
                 case Chapter.Type.Chapter5:
+                case Chapter.Type.HardmodeChapter5:
                     rarity = Rarity.Legendary;
                     break;
             }

--- a/Skul.Mod/Plugin.cs
+++ b/Skul.Mod/Plugin.cs
@@ -9,8 +9,6 @@ using System.Security.Cryptography.X509Certificates;
 using BepInEx;
 using BepInEx.Bootstrap;
 using BepInEx.Logging;
-using BepInEx.Unity;
-using BepInEx.Unity.Bootstrap;
 using Characters.Controllers;
 using Data;
 using HarmonyLib;

--- a/Skul.Mod/Skul.Mod.csproj
+++ b/Skul.Mod/Skul.Mod.csproj
@@ -18,7 +18,7 @@
   <!-- Enter the path to your Skul Installation here -->
   <PropertyGroup Condition="'$(OS)' == 'Unix'">
     <SkulDirectory>$(HOME)/.steam/debian-installation/steamapps/common/Skul/</SkulDirectory>
-    <OutputPath>$(SkulDirectory)BepInEx/plugins/</OutputPath>
+    <OutputPath>$(SkulDirectory)BepInEx/plugins/Tobi.Mob-Skul.Mod/</OutputPath>
     <RestoreSources>$(RestoreSources);../Packages/</RestoreSources>
   </PropertyGroup>
 
@@ -26,7 +26,7 @@
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
     <SkulDirectory>C:\Program Files\Steam\steamapps\common\Skul\</SkulDirectory>
     <SkulDirectory Condition="Exists('C:\Program Files (x86)\Steam\steamapps\common\Skul\')">C:\Program Files (x86)\Steam\steamapps\common\Skul\</SkulDirectory>
-    <OutputPath>$(SkulDirectory)BepInEx\plugins\</OutputPath>
+    <OutputPath>$(SkulDirectory)BepInEx\plugins\Tobi.Mob-Skul.Mod\</OutputPath>
     <RestoreSources>$(RestoreSources);..\Packages\</RestoreSources>
   </PropertyGroup>
 

--- a/Skul.Mod/Skul.Mod.csproj
+++ b/Skul.Mod/Skul.Mod.csproj
@@ -32,7 +32,7 @@
 
   <ItemGroup>
     <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />
-    <PackageReference Include="BepInEx.Unity" Version="6.0.0-*" IncludeAssets="compile" />
+    <PackageReference Include="BepInEx.Core" Version="5.*" IncludeAssets="compile" />
     <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" />
 	  <PackageReference Include="UnityEngine.Modules" Version="2020.3.24" IncludeAssets="compile" />
   </ItemGroup>


### PR DESCRIPTION
Hello! I'm working on the [Skul Hard Mode Mod Pack](https://github.com/MrBacanudo/SkulHardModeMods) and one of the requests I got a few times is to be compatible with your mod.

As you noted in your documentation, BepInEx 6 has no stable release, but they also recommend making v5 mods, as the stable release will then be backwards-compatible with them.

So this is an offer: we can allow all mods to work well together! By either publishing a second version that's compatible with v5, or changing the main one, as it currently does not use any of BepInEx 6's functionality.

This pull request assumes the latter.

If accepted, these would be the steps to follow this PR:

- [ ] Test on Linux
- [x] Remove BepInEx 6 references from the documentation
- [x] Only publish the `Skul.Mod.dll` assembly, instead of all dependencies? (All dependencies should be loaded by BepInEx during injection, so they should be unnecessary files. Because of that, I put the assemblies on their own folder on the second commit)